### PR TITLE
fix: change src file import path

### DIFF
--- a/src/bilifm/__init__.py
+++ b/src/bilifm/__init__.py
@@ -1,1 +1,1 @@
-from bilifm.command import app
+from .command import app

--- a/src/bilifm/audio.py
+++ b/src/bilifm/audio.py
@@ -5,7 +5,7 @@ import time
 import requests
 import typer
 
-from bilifm.util import get_signed_params
+from .util import get_signed_params
 
 
 class Audio:

--- a/src/bilifm/command.py
+++ b/src/bilifm/command.py
@@ -1,8 +1,8 @@
 import typer
 
-from bilifm.audio import Audio
-from bilifm.fav import Fav
-from bilifm.user import User
+from .audio import Audio
+from .fav import Fav
+from .user import User
 
 app = typer.Typer()
 

--- a/src/bilifm/fav.py
+++ b/src/bilifm/fav.py
@@ -1,6 +1,6 @@
 import json
 
-from bilifm.util import request
+from .util import request
 
 
 class Fav:

--- a/src/bilifm/user.py
+++ b/src/bilifm/user.py
@@ -1,6 +1,6 @@
 import typer
 
-from bilifm.util import request
+from .util import request
 
 
 class User:


### PR DESCRIPTION
包内为什么不用相对引用啊.
用绝对引用的话, 不安装这个库就无法使用 main.py脚本了, 同时要修改也要对安装的lib内的文件进行修改.