### PR TITLE
provide audio quality option 添加下载音质的 CLI 选项

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ temp/
 .DS_Store
 
 .pdm-python
+
+.idea/

--- a/src/bilifm/audio.py
+++ b/src/bilifm/audio.py
@@ -5,7 +5,7 @@ import time
 import requests
 import typer
 
-from .util import AudioQualityEnums, audio_quality_map, get_signed_params
+from .util import AudioQualityEnums, get_signed_params
 
 
 class Audio:
@@ -40,7 +40,7 @@ class Audio:
             "Referer": "https://www.bilibili.com/video/{bvid}".format(bvid=self.bvid),
         }
 
-        self.audio_quality = audio_quality_map[audio_quality.value]
+        self.audio_quality = audio_quality.quality_id
 
         # 获取cid和title
         if len(bvid) == 12:

--- a/src/bilifm/audio.py
+++ b/src/bilifm/audio.py
@@ -5,7 +5,7 @@ import time
 import requests
 import typer
 
-from .util import get_signed_params
+from .util import get_signed_params, AudioQualityEnums, audio_quality_map
 
 
 class Audio:
@@ -16,7 +16,7 @@ class Audio:
 
     headers = {}
 
-    def __init__(self, bvid: str) -> None:
+    def __init__(self, bvid: str, audio_quality: AudioQualityEnums) -> None:
         if bvid is None:
             raise ValueError("bvid is None")
 
@@ -39,6 +39,8 @@ class Audio:
             "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
             "Referer": "https://www.bilibili.com/video/{bvid}".format(bvid=self.bvid),
         }
+
+        self.audio_quality = audio_quality_map[audio_quality.value]
 
         # 获取cid和title
         if len(bvid) == 12:
@@ -76,9 +78,25 @@ class Audio:
                     self.playUrl, params=params, headers=self.headers
                 ).json()
 
-                baseUrl = json["data"]["dash"]["audio"][0]["baseUrl"]
+                if json["data"] is None:
+                    typer.echo(f" `data` field is not valid with url: {self.playUrl} and params : {params}")
+                    return
 
-                response = requests.get(url=baseUrl, headers=self.headers, stream=True)
+                audio = json["data"]["dash"]["audio"]
+                if not audio:
+                    typer.echo(f" `audio` field is empty with url: {self.playUrl} and params : {params}")
+                    return
+
+                base_url = None
+                for au in audio:
+                    if au["id"] == self.audio_quality:
+                        base_url = au["baseUrl"]
+
+                # no audio url corresponding to current audio quality
+                if base_url is None:
+                    base_url = audio[0]["baseUrl"]
+
+                response = requests.get(url=base_url, headers=self.headers, stream=True)
 
                 total_size = int(response.headers.get("content-length", 0))
                 temp_size = 0

--- a/src/bilifm/audio.py
+++ b/src/bilifm/audio.py
@@ -5,7 +5,7 @@ import time
 import requests
 import typer
 
-from .util import get_signed_params, AudioQualityEnums, audio_quality_map
+from .util import AudioQualityEnums, audio_quality_map, get_signed_params
 
 
 class Audio:
@@ -79,12 +79,16 @@ class Audio:
                 ).json()
 
                 if json["data"] is None:
-                    typer.echo(f" `data` field is not valid with url: {self.playUrl} and params : {params}")
+                    typer.echo(
+                        f" `data` field is not valid with url: {self.playUrl} and params : {params}"
+                    )
                     return
 
                 audio = json["data"]["dash"]["audio"]
                 if not audio:
-                    typer.echo(f" `audio` field is empty with url: {self.playUrl} and params : {params}")
+                    typer.echo(
+                        f" `audio` field is empty with url: {self.playUrl} and params : {params}"
+                    )
                     return
 
                 base_url = None

--- a/src/bilifm/command.py
+++ b/src/bilifm/command.py
@@ -82,7 +82,12 @@ def season(
 
 
 @app.command()
-def series(uid: str, sid: str, directory: Directory = None, audio_quality: AudioQuality = AudioQualityEnums.k64):
+def series(
+    uid: str,
+    sid: str,
+    directory: Directory = None,
+    audio_quality: AudioQuality = AudioQualityEnums.k64,
+):
     """Download bilibili video series
 
     The api of series lacks the series name, executing

--- a/src/bilifm/command.py
+++ b/src/bilifm/command.py
@@ -16,7 +16,7 @@ app = typer.Typer()
 def bv(
     bv: str,
     directory: Directory = None,
-    audio_quality: AudioQuality = AudioQualityEnums.k192,
+    audio_quality: AudioQuality = AudioQualityEnums.k192.value,
 ):
     audio = Audio(bv, audio_quality)
     audio.download()
@@ -26,7 +26,7 @@ def bv(
 def uid(
     uid: str,
     directory: Directory = None,
-    audio_quality: AudioQuality = AudioQualityEnums.k192,
+    audio_quality: AudioQuality = AudioQualityEnums.k192.value,
 ):
     user = User(uid)
 
@@ -43,7 +43,7 @@ def fav(
     media_id: str,
     cookies_path: str = Path,
     directory: Directory = None,
-    audio_quality: AudioQuality = AudioQualityEnums.k192,
+    audio_quality: AudioQuality = AudioQualityEnums.k192.value,
 ):
     with open(cookies_path, "r") as f:
         cookies = f.read()
@@ -62,7 +62,7 @@ def season(
     uid: str,
     sid: str,
     directory: Directory = None,
-    audio_quality: AudioQuality = AudioQualityEnums.k192,
+    audio_quality: AudioQuality = AudioQualityEnums.k192.value,
 ):
     sea = Season(uid, sid)
     audio_generator = sea.get_videos()

--- a/src/bilifm/command.py
+++ b/src/bilifm/command.py
@@ -16,7 +16,7 @@ app = typer.Typer()
 def bv(
     bv: str,
     directory: Directory = None,
-    audio_quality: AudioQuality = AudioQualityEnums.k64,
+    audio_quality: AudioQuality = AudioQualityEnums.k192,
 ):
     audio = Audio(bv, audio_quality)
     audio.download()
@@ -26,7 +26,7 @@ def bv(
 def uid(
     uid: str,
     directory: Directory = None,
-    audio_quality: AudioQuality = AudioQualityEnums.k64,
+    audio_quality: AudioQuality = AudioQualityEnums.k192,
 ):
     user = User(uid)
 
@@ -43,7 +43,7 @@ def fav(
     media_id: str,
     cookies_path: str = Path,
     directory: Directory = None,
-    audio_quality: AudioQuality = AudioQualityEnums.k64,
+    audio_quality: AudioQuality = AudioQualityEnums.k192,
 ):
     with open(cookies_path, "r") as f:
         cookies = f.read()
@@ -62,7 +62,7 @@ def season(
     uid: str,
     sid: str,
     directory: Directory = None,
-    audio_quality: AudioQuality = AudioQualityEnums.k64,
+    audio_quality: AudioQuality = AudioQualityEnums.k192,
 ):
     sea = Season(uid, sid)
     audio_generator = sea.get_videos()

--- a/src/bilifm/command.py
+++ b/src/bilifm/command.py
@@ -7,24 +7,24 @@ from .fav import Fav
 from .season import Season
 from .series import Series
 from .user import User
-from .util import Directory, Path
+from .util import Directory, Path, AudioQuality, AudioQualityEnums
 
 app = typer.Typer()
 
 
 @app.command()
-def bv(bv: str, directory: Directory = None):
-    audio = Audio(bv)
+def bv(bv: str, directory: Directory = None, audio_quality: AudioQuality = AudioQualityEnums.k64):
+    audio = Audio(bv, audio_quality)
     audio.download()
 
 
 @app.command()
-def uid(uid: str, directory: Directory = None):
+def uid(uid: str, directory: Directory = None, audio_quality: AudioQuality = AudioQualityEnums.k64):
     user = User(uid)
 
     for video in user.videos:
         bv = video["bvid"]
-        audio = Audio(bv)
+        audio = Audio(bv, audio_quality)
         audio.download()
 
     typer.echo("Download complete")
@@ -35,6 +35,7 @@ def fav(
     media_id: str,
     cookies_path: str = Path,
     directory: Directory = None,
+    audio_quality: AudioQuality = AudioQualityEnums.k64
 ):
     with open(cookies_path, "r") as f:
         cookies = f.read()
@@ -42,14 +43,14 @@ def fav(
     fav = Fav(media_id, cookies)
 
     for bvid in fav.id_list:
-        audio = Audio(bvid)
+        audio = Audio(bvid, audio_quality)
         audio.download()
 
     typer.echo("Download complete")
 
 
 @app.command()
-def season(uid: str, sid: str, directory: Directory = None):
+def season(uid: str, sid: str, directory: Directory = None, audio_quality: AudioQuality = AudioQualityEnums.k64):
     sea = Season(uid, sid)
     audio_generator = sea.get_videos()
     if not audio_generator:
@@ -62,13 +63,13 @@ def season(uid: str, sid: str, directory: Directory = None):
 
     for audios in audio_generator:
         for id in audios:
-            audio = Audio(id)
+            audio = Audio(id, audio_quality)
             audio.download()
     typer.echo("Download complete")
 
 
 @app.command()
-def series(uid: str, sid: str, directory: Directory = None):
+def series(uid: str, sid: str, directory: Directory = None, audio_quality: AudioQuality = AudioQualityEnums.k64):
     """Download bilibili video series
 
     The api of series lacks the series name, executing
@@ -82,6 +83,6 @@ def series(uid: str, sid: str, directory: Directory = None):
 
     for audios in audio_generator:
         for id in audios:
-            audio = Audio(id)
+            audio = Audio(id, audio_quality)
             audio.download()
     typer.echo("Download complete")

--- a/src/bilifm/command.py
+++ b/src/bilifm/command.py
@@ -7,19 +7,27 @@ from .fav import Fav
 from .season import Season
 from .series import Series
 from .user import User
-from .util import Directory, Path, AudioQuality, AudioQualityEnums
+from .util import AudioQuality, AudioQualityEnums, Directory, Path
 
 app = typer.Typer()
 
 
 @app.command()
-def bv(bv: str, directory: Directory = None, audio_quality: AudioQuality = AudioQualityEnums.k64):
+def bv(
+    bv: str,
+    directory: Directory = None,
+    audio_quality: AudioQuality = AudioQualityEnums.k64,
+):
     audio = Audio(bv, audio_quality)
     audio.download()
 
 
 @app.command()
-def uid(uid: str, directory: Directory = None, audio_quality: AudioQuality = AudioQualityEnums.k64):
+def uid(
+    uid: str,
+    directory: Directory = None,
+    audio_quality: AudioQuality = AudioQualityEnums.k64,
+):
     user = User(uid)
 
     for video in user.videos:
@@ -35,7 +43,7 @@ def fav(
     media_id: str,
     cookies_path: str = Path,
     directory: Directory = None,
-    audio_quality: AudioQuality = AudioQualityEnums.k64
+    audio_quality: AudioQuality = AudioQualityEnums.k64,
 ):
     with open(cookies_path, "r") as f:
         cookies = f.read()
@@ -50,7 +58,12 @@ def fav(
 
 
 @app.command()
-def season(uid: str, sid: str, directory: Directory = None, audio_quality: AudioQuality = AudioQualityEnums.k64):
+def season(
+    uid: str,
+    sid: str,
+    directory: Directory = None,
+    audio_quality: AudioQuality = AudioQualityEnums.k64,
+):
     sea = Season(uid, sid)
     audio_generator = sea.get_videos()
     if not audio_generator:

--- a/src/bilifm/util.py
+++ b/src/bilifm/util.py
@@ -97,6 +97,7 @@ mixinKeyEncTab = [
     52,
 ]
 
+
 class AudioQualityEnums(str, Enum):
     k64 = "64"
     k132 = "132"
@@ -229,5 +230,6 @@ class Retry:
         return wrapped_request
 
 AudioQuality = Annotated[
-    AudioQualityEnums, typer.Option("--quality", "-q", help="audio quality",
-                                    case_sensitive=False)]
+    AudioQualityEnums,
+    typer.Option("--quality", "-q", help="audio quality", case_sensitive=False),
+]

--- a/src/bilifm/util.py
+++ b/src/bilifm/util.py
@@ -98,17 +98,22 @@ mixinKeyEncTab = [
 ]
 
 
-class AudioQualityEnums(str, Enum):
-    k64 = "64"
-    k132 = "132"
-    k192 = "192"
-
-
+# 音质映射到具体值
 audio_quality_map = {
     "64": 30216,
     "132": 30232,
     "192": 30280,
 }
+
+
+class AudioQualityEnums(str, Enum):
+    k64 = "64"
+    k132 = "132"
+    k192 = "192"
+
+    @property
+    def quality_id(self):
+        return audio_quality_map[self._value_]
 
 
 def getMixinKey(orig: str):

--- a/src/bilifm/util.py
+++ b/src/bilifm/util.py
@@ -234,6 +234,7 @@ class Retry:
 
         return wrapped_request
 
+
 AudioQuality = Annotated[
     AudioQualityEnums,
     typer.Option("--quality", "-q", help="audio quality", case_sensitive=False),

--- a/src/bilifm/util.py
+++ b/src/bilifm/util.py
@@ -2,6 +2,7 @@ import os
 import random
 import time
 import urllib.parse
+from enum import Enum
 from functools import reduce
 from hashlib import md5
 from typing import Callable
@@ -95,6 +96,18 @@ mixinKeyEncTab = [
     44,
     52,
 ]
+
+class AudioQualityEnums(str, Enum):
+    k64 = "64"
+    k132 = "132"
+    k192 = "192"
+
+
+audio_quality_map = {
+    "64": 30216,
+    "132": 30232,
+    "192": 30280,
+}
 
 
 def getMixinKey(orig: str):
@@ -214,3 +227,7 @@ class Retry:
             return None
 
         return wrapped_request
+
+AudioQuality = Annotated[
+    AudioQualityEnums, typer.Option("--quality", "-q", help="audio quality",
+                                    case_sensitive=False)]


### PR DESCRIPTION
## description
According to [添加下载音质的 CLI 选项](https://codekitchen.community/t/topic/1300/2#q1-1) :

just provide three audio quality options:  **64**, **132** and **192** .

## Usage
The default value of audio quality is **64** .
![image](https://github.com/jingfelix/BiliFM/assets/81068011/63a3af45-eafa-4054-b263-33002ef294df)

set audio quality to **132**

```bash
bilifm uid xxxx -q 132
```

**192**  same as above

```bash
bilifm uid xxxx -q 192
```