### PR TITLE
add github actions to publish on pypi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,35 @@
+name: publish to pypi
+
+"on":
+  push:
+    tags:
+      - 'v*'
+  workflow_run:
+    workflows: ["Pre-Commit Check"]
+    types: completed
+    conclusion: success
+
+
+jobs:
+  release_to_pypi:
+    name: Release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/bilifm
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup pdm
+        id: setup-pdm
+        uses: pdm-project/setup-pdm@v4
+      - name: Check output
+        run: |
+          echo ${{ steps.setup-pdm.outputs.pdm-bin }}
+          echo ${{ steps.setup-pdm.outputs.pdm-version }}
+          echo ${{ steps.setup-pdm.outputs.python-path }}
+          echo ${{ steps.setup-pdm.outputs.python-version }}
+      - name: pypi-publish-by-pdm
+        run: pdm publish


### PR DESCRIPTION
No pypi token required, just add a trusted publisher to an existing pypi project, by this link: [Adding a Trusted Publisher to an Existing PyPI Project - PyPI Docs](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) .

**It should be noted that you need to manually update the `version` in `pyproject.toml` before pushes or prs** . 

I have used github actions and published pypi package .  look at : [sphinxcontrib-analytics-hub/.github/workflows/python-publish.yml at main · un4gt/sphinxcontrib-analytics-hub](https://github.com/un4gt/sphinxcontrib-analytics-hub/blob/main/.github/workflows/python-publish.yml)