### PR TITLE
fix: use generic Referer to avoid 412 from playurl endpoint

### DIFF
--- a/src/bilifm/audio.py
+++ b/src/bilifm/audio.py
@@ -51,7 +51,7 @@ class Audio:
             "sec-fetch-user": "?1",
             "upgrade-insecure-requests": "1",
             "user-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
-            "Referer": "https://www.bilibili.com/video/{bvid}".format(bvid=self.bvid),
+            "Referer": "https://www.bilibili.com/",
         }
 
         self.audio_quality = audio_quality.quality_id


### PR DESCRIPTION
## Summary

- Fix 412 Precondition Failed error when downloading audio from playurl endpoint
- The video-specific Referer (`/video/{bvid}`) triggers Bilibili's anti-scraping detection, returning 412. Using the base URL (`https://www.bilibili.com/`) resolves this.

## Test plan

- [x] Test download with `python main.py bv BV1VrovBhE5e` succeeds without 412 error
- [x] Verify WBI signing still works with the updated Referer

🤖 Generated with [Claude Code](https://claude.com/claude-code)