### PR TITLE
fix: use stdlib typing.Annotated instead of typing_extensions

### DIFF
--- a/src/bilifm/util.py
+++ b/src/bilifm/util.py
@@ -7,11 +7,10 @@ import urllib.parse
 from enum import Enum
 from functools import reduce
 from hashlib import md5
-from typing import Callable
+from typing import Annotated, Callable
 
 import requests
 import typer
-from typing_extensions import Annotated
 
 HEADERS = {
     "authority": "api.bilibili.com",


### PR DESCRIPTION
## Summary

- Replace `from typing_extensions import Annotated` with `from typing import Annotated`
- `typing.Annotated` is available since Python 3.9, and the project requires >=3.10, so `typing_extensions` is unnecessary
- Fixes `ModuleNotFoundError: No module named 'typing_extensions'` when installing with `uv tool install` or in environments where `typing_extensions` is not pre-installed

## Test plan

- [x] `bilifm --help` works after `uv tool install`
- [x] `python main.py bv BV1VrovBhE5e` downloads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)